### PR TITLE
Correct the error that occurs when installing in Chinese with the mes…

### DIFF
--- a/EET_Tweaks/lib/always.tph
+++ b/EET_Tweaks/lib/always.tph
@@ -43,7 +43,7 @@ ACTION_DEFINE_ASSOCIATIVE_ARRAY charsetsTable BEGIN
 	"ru_ru" => "CP1251"
 	//"tr_tr" => ""
 	//"uk_ua" => ""
-	//"zh_cn" => ""
+	"zh_cn" => "CP65001"
 END
 ACTION_DEFINE_ARRAY charsetsConvertArray BEGIN voices ironman categorization wandcase END
 LAF HANDLE_CHARSETS


### PR DESCRIPTION
Correct the error that occurs when installing in Chinese with the message 'tabulated charset could found'.